### PR TITLE
fix(scene): Default values for fixtures & animations

### DIFF
--- a/src/components/scene-manager/index.js
+++ b/src/components/scene-manager/index.js
@@ -22,6 +22,13 @@ class SceneManager extends connect(store)(LitElement) {
     }
   }
 
+  constructor() {
+    super()
+
+    this._fixtures = []
+    this._animations = []
+  }
+
   _stateChanged(state) {
     this.scenes = getScenesSorted(state)
     this.fixtureManager = getFixtures(state)

--- a/src/components/timeline/timeline-scene.js
+++ b/src/components/timeline/timeline-scene.js
@@ -53,7 +53,7 @@ class TimelineScene extends connect(store)(LitElement) {
    */
   noAnimationInScene(animations) {
 
-    if (animations.length === 0) {
+    if (animations === undefined || animations.length === 0) {
       return html`<mwc-icon title="No animation is assigned to this Scene">error</mwc-icon>`
     }
 


### PR DESCRIPTION
Set default values for the fixtures & animations of a scene. Make sure that animations exist on a
scene when checking if the scene has no animations.
